### PR TITLE
chore(repo): enforce LF line endings via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+# Set LF for shell scripts to avoid execution issues on Linux
+*.sh text eol=lf
+
+# Normalize common text files
+*.md text eol=lf
+*.yml text eol=lf
+*.yaml text eol=lf
+Dockerfile text eol=lf
+*.service text eol=lf
+*.conf text eol=lf
+*.env.example text eol=lf
+
+# Auto-detect
+* text=auto


### PR DESCRIPTION
This PR adds a .gitattributes file to enforce LF line endings for shell scripts and common text files. This prevents execution issues on Linux (e.g., bad interpreter errors) when scripts are edited on Windows.

Changes
- Enforce LF for: *.sh, *.md, *.yml, *.yaml, Dockerfile, *.service, *.conf, *.env.example
- Keep text=auto as a baseline for other files

Why
- Ensure consistent line endings across platforms
- Avoid runtime errors in deployment/install scripts

Testing
- After merging, a fresh clone on Linux should produce scripts with LF endings.

Changelog
- chore(repo): enforce LF line endings for shell scripts and docs via .gitattributes