### PR TITLE
fix: avoid unbound variable in install script

### DIFF
--- a/one-line-install.sh
+++ b/one-line-install.sh
@@ -908,4 +908,4 @@ EOF
 chown codeseek:codeseek "$APP_DIR/installation-info.txt"
 chmod 600 "$APP_DIR/installation-info.txt"
 
-echo -e "${INFO}💾 Informações da instalação salvas em: $APP_DIR/installation-info.txt${NC}\n"
+info "💾 Informações da instalação salvas em: $APP_DIR/installation-info.txt"


### PR DESCRIPTION
## Summary
- fix undefined `INFO` variable in one-line installer

## Testing
- `bash -n one-line-install.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b8a3dbfab48323aa474e16e2abae0c